### PR TITLE
Added possibility to add cheerio options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode
 .DS_Store
+*.iml

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,15 @@
 var gulp = require('gulp');
 var base64 = require('./index');
 
+var options = {
+    cheerio: {
+        xmlMode: true,
+        lowerCaseTags: false
+    }
+}
+
 gulp.task('default', function(){
     return gulp.src(['test/files/*.html'])
-    .pipe(base64())
+    .pipe(base64(options))
     .pipe(gulp.dest('test/dist/'));
 });

--- a/inline-images.js
+++ b/inline-images.js
@@ -16,6 +16,7 @@ const NOT_INLINE_ATTR = `!${INLINE_ATTR}`;
 function plugin(options = {}){
 	var selector = options.selector || 'img[src]';
 	var attribute = options.attribute || 'src';
+	var cheerioOptions = options.cheerio || {};
 
 	return through.obj(function(file, encoding, callback){
 		if(file.isStream()){
@@ -26,7 +27,7 @@ function plugin(options = {}){
 		if(file.isBuffer()){
 			var contents = file.contents.toString(encoding);
 			// Load it into cheerio's virtual DOM for easy manipulation
-			var $ = cheerio.load(contents);
+			var $ = cheerio.load(contents, cheerioOptions);
 			var inline_flag = $(`img[${INLINE_ATTR}]`);
 			// If images with an inline attr are found that is the selection we want
 			var img_tags = inline_flag.length ? inline_flag : $(selector);


### PR DESCRIPTION
Hi,

im using your plugin to make inline images for my Angular modules. However the original angular tags were set to lowercase; e.g.

<div *ngFor="let row of rows"></div>

_became_

<div *ngfor="let row of rows"></div>

I've added the possibility to add the cheerio options to your plugin so you can set the 'lowercasing' to false. 

Hope you like it! :)
