### PR TITLE
Make http-inline optional 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ gulp.task('inline-images', function(){
 | selector  | ```String``` | ```'img[src]'``` | Selection of elements to process |
 | attribute | ```String``` | ```'src'```      | Attribute name for source URL    |
 | basedir   | ```String``` | Source file dir  | Base directory of local images   |
+| getHTTP   | ```Boolean```| false            | Inline 'http' images             |
 
 ## inline attribute
 To limit this plugin to specific img elements add an ```inline``` attribute to only the img tags you want to process.

--- a/inline-images.js
+++ b/inline-images.js
@@ -56,25 +56,28 @@ function plugin(options = {}){
 				count++;
 
 				getSrcBase64(options.basedir || file.base, options.getHTTP, src, function(err, result, res_format, skip_formatting){
-					if(skip_formatting) return src
-
-					if(err) console.error(err);
-					else
-					// Need a format in and a result for this to work
-					if(result && (ext_format || res_format)){
-						$img.attr('src', `data:image/${ext_format};base64,${result}`);
+					if (err) { 
+						console.error(err);
 					} else {
-						console.error(`Failed to identify format of ${src}!`);
-					}
-					if(!--count){
-						file.contents = Buffer.from($.html());
-						callback(null, file);
+						// Need a format in and a result for this to work
+						if (!skip_formatting) {
+							if(result && (ext_format || res_format)){
+								$img.attr('src', `data:image/${ext_format};base64,${result}`);
+							} else {
+								console.error(`Failed to identify format of ${src}!`);
+							}
+						}
+
+						if(!--count){
+							file.contents = Buffer.from($.html());
+							callback(null, file);
+						}
 					}
 				});
 			});
 
 			// If no files are processing we don't need to wait as none were ever started
-			if(!count){
+			if (!img_tags.length){
 				file.contents = Buffer.from($.html());
 				callback(null, file);
 			}

--- a/inline-images.js
+++ b/inline-images.js
@@ -55,7 +55,7 @@ function plugin(options = {}){
 				// Count async ops
 				count++;
 
-				getSrcBase64(options.basedir || file.base, options.getHTTP, src, function(err, result, res_format, skip_formatting){
+				getSrcBase64(options.basedir || file.base, getHTTP, src, function(err, result, res_format, skip_formatting){
 					if (err) { 
 						console.error(err);
 					} else {

--- a/inline-images.js
+++ b/inline-images.js
@@ -16,6 +16,7 @@ const NOT_INLINE_ATTR = `!${INLINE_ATTR}`;
 function plugin(options = {}){
 	var selector = options.selector || 'img[src]';
 	var attribute = options.attribute || 'src';
+	var getHTTP = options.getHTTP || false;
 
 	return through.obj(function(file, encoding, callback){
 		if(file.isStream()){
@@ -54,7 +55,7 @@ function plugin(options = {}){
 				// Count async ops
 				count++;
 
-				getSrcBase64(options.basedir || file.base, src, function(err, result, res_format){
+				getSrcBase64(options.basedir || file.base, options.getHTTP, src, function(err, result, res_format){
 					if(err) console.error(err);
 					else
 					// Need a format in and a result for this to work
@@ -114,14 +115,18 @@ function getHTTPBase64(url, callback) {
 	req.on('error', (err) => callback(err));
 }
 
-function getSrcBase64(base, src, callback){
+function getSrcBase64(base, getHTTP, src, callback){
 	if(!url.parse(src).hostname){
 		// Get local file
 		var file_path = path.join(base, src);
 		fs.readFile(file_path, 'base64', callback);
 	}else{
 		// Get remote file
-		getHTTPBase64(src, callback);
+		if (getHTTP) {
+			getHTTPBase64(src, callback);
+		} else {
+			callback(null, src)
+		}
 	}    
 }
 

--- a/inline-images.js
+++ b/inline-images.js
@@ -55,7 +55,9 @@ function plugin(options = {}){
 				// Count async ops
 				count++;
 
-				getSrcBase64(options.basedir || file.base, options.getHTTP, src, function(err, result, res_format){
+				getSrcBase64(options.basedir || file.base, options.getHTTP, src, function(err, result, res_format, skip_formatting){
+					if(skip_formatting) return src
+
 					if(err) console.error(err);
 					else
 					// Need a format in and a result for this to work
@@ -125,7 +127,7 @@ function getSrcBase64(base, getHTTP, src, callback){
 		if (getHTTP) {
 			getHTTPBase64(src, callback);
 		} else {
-			callback(null, src)
+			callback(null, src, null, true)
 		}
 	}    
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gulp-inline-images-no-http",
+  "name": "gulp-inline-images",
   "version": "1.3.0",
   "description": "Gulp plugin for converting linked HTML images into base64 encoded inline images. Works with local and remote files.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gulp-inline-images",
-  "version": "1.2.6",
+  "name": "gulp-inline-images-no-http",
+  "version": "1.3.0",
   "description": "Gulp plugin for converting linked HTML images into base64 encoded inline images. Works with local and remote files.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Hi @imaustink,
Regarding your comment, I think it's easier to understand what I did with the code if you look at the bigger picture.
Essentially, I've made inlining `http` images optional (NB: default is `false`) and had to adjust the code a bit to make it work.

---------------------

Here's the use case: I use this plugin for inlining images in HTML emails ([here](https://github.com/fadeit/responsive-html-email-signature)). Depending on what email clients people want to support, they might want to inline images or not.

All email clients support loading remote images, but only the modern ones support base64 images. 
As a result, in most cases when people use http they actually want the image to be loaded remotely and not inlined.  

The 'inline' attribute (or having getHTTP = true as default for that matter) would break the code for everybody that used the HTML email generator before, so I'd rather avoid that.

Let me know if this makes sense to you. Apologies for not addressing this issue with you beforehand, it would have been more in line with the open source spirit IMO... but I was really in a hurry :)

Dan 