### PR TITLE
Make the 'attribute' option work

### DIFF
--- a/inline-images.js
+++ b/inline-images.js
@@ -59,7 +59,7 @@ function plugin(options = {}){
 					else
 					// Need a format in and a result for this to work
 					if(result && (ext_format || res_format)){
-						$img.attr('src', `data:image/${ext_format};base64,${result}`);
+						$img.attr(attribute, `data:image/${ext_format};base64,${result}`);
 					} else {
 						console.error(`Failed to identify format of ${src}!`);
 					}


### PR DESCRIPTION
The 'attribute' option currently reads a custom attribute, but it always sets the 'src' attribute. This fix changes it to write the same attribute that it reads.