### PR TITLE
Fix inlining of SVG images by changing its mime-type

### DIFF
--- a/inline-images.js
+++ b/inline-images.js
@@ -38,6 +38,7 @@ function plugin(options = {}){
 				var src = $img.attr(attribute);
 				// Save the file format from the extension
 				var ext_format = path.extname(src).substr(1);
+				if (ext_format == "svg") ext_format = "svg+xml";
 
 				// If inline_flag tags were found we want to remove the inline tag
 				if(inline_flag.length){


### PR DESCRIPTION
SVG were not being inlined correctly due to it's mime-type being defined as `image/svg`, were it should be `image/svg+xml`.

Before:
![imagem](https://github.com/imaustink/gulp-inline-images/assets/28317418/754c0606-d77a-4643-95db-afe2c230fdea)

After:
![imagem](https://github.com/imaustink/gulp-inline-images/assets/28317418/1f41b619-9563-4378-9444-123bac4a2b4b)
